### PR TITLE
Normal user can capture traffic.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ansible-role-wireshark
-wireshark_user: "{{ lookup('env','USER') }}"
+wireshark_user: "{{ ansible_user_id }}"
 wireshark_gui: false
 wireshark_cli: true
 wireshark_gui_package: wireshark

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,5 @@
 wireshark_user: "{{ lookup('env','USER') }}"
 wireshark_gui: false
 wireshark_cli: true
-wireshark_gui_package: wireshark-common
+wireshark_gui_package: wireshark
 wireshark_cli_package: tshark

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: run apt-get update
   apt:
     update_cache: yes
+  become: yes
 
 - name: install cli package
   apt:
@@ -11,21 +12,25 @@
     state: present
   with_items: "{{ wireshark_cli_package }}"
   when: wireshark_cli
+  become: yes
 
 - name: install gui package
   apt:
     name: "{{ item }}"
     state: present
-  with_items: "{{ wireshark_cli_package }}"
+  with_items: "{{ wireshark_gui_package }}"
   when: wireshark_gui
+  become: yes
 
 - name: create wireshark group
   group:
     name: wireshark
     state: present
+  become: yes
 
 - name: add current user to wireshark group
   user:
     name: "{{ wireshark_user }}"
     append: yes
     groups: wireshark
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,15 @@
     update_cache: yes
   become: yes
 
+- name: let non root to capture traffic
+  # Before installing any package, this only sets the preference for the question
+  debconf:
+    name='wireshark-common'
+    question='wireshark-common/install-setuid'
+    vtype='boolean'
+    value='true'
+  become: yes
+
 - name: install cli package
   apt:
     name: "{{ item }}"
@@ -20,12 +29,6 @@
     state: present
   with_items: "{{ wireshark_gui_package }}"
   when: wireshark_gui
-  become: yes
-
-- name: create wireshark group
-  group:
-    name: wireshark
-    state: present
   become: yes
 
 - name: add current user to wireshark group


### PR DESCRIPTION
This PR depends on https://github.com/ymajik/ansible-role-wireshark/pull/1.

While installing wireshark-common, dpkg recommends to allow non root
users to capture traffic. To do so, we answer with "yes" the question
'wireshark-common/install-setuid'.

"debconf" only sets the default option to that question, does not submit
it. Therefore, we must set it _before_ we install any package.

On the other hand, it is not needed to create the "wireshark" group
manually because dpkg will do it for us. Nevertheless, we need to add
our user to the group to enable this capability for it.
